### PR TITLE
Update Plugin.php

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -35,6 +35,6 @@ class Plugin extends Base
     
     public function getPluginHomepage()
     {
-        return "https://github.com/Chaosmeister/CCIT"
+        return "https://github.com/Chaosmeister/CCIT";
     }
 }


### PR DESCRIPTION
Kanboard version : 1.2.20
PHP version : 7.4.25
PHP SAPI : fpm-fcgi

Blank page on kanboard after installing the ClickableCheckboxInTextAreas plugin.
Error in apache log files : AH01071: Got error 'PHP message: PHP Parse error:  syntax error, unexpected '}', expecting ';' in /var/www/kanboard/plugins/CCIT/Plugin.php on line 39'
Added a semicolon to close the return statement in the getPluginHomepage function.