### PR TITLE
Support ENABLE_URL_REWRITE Kanboard option.

### DIFF
--- a/Assets/js/CCIT.js
+++ b/Assets/js/CCIT.js
@@ -1,6 +1,6 @@
 KB.on('dom.ready', function() {
     const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.get('controller') == "TaskViewController" && urlParams.get('action') == 'show') {
+    if ((urlParams.get('controller') == "TaskViewController" && urlParams.get('action') == 'show') || /\/task\/[0-9]+$/.test(window.location)) {
         var Content = document.getElementsByClassName('sidebar-content')[0];
 
         const elements = [...Content.getElementsByTagName('input')];


### PR DESCRIPTION
Assets/js/CCIT.js: Support pretty URLs from the ENABLE_URL_REWRITE Kanboard option. That option not only produces nicer URLs, but is also required for the GitLab integration to work. So make CCIT.js work on those pretty URLs. (Instead of using the parameters controller=TaskViewController&action=show, those URLs are of the form https://example.com/kanboard/task/123, i.e., they match the regex "/task/[0-9]+$".)